### PR TITLE
Use consistent parameter names for Sign and Verify functions

### DIFF
--- a/rfc6979.go
+++ b/rfc6979.go
@@ -14,10 +14,10 @@ const (
 	// RFC6979SignatureSize contains r and s coordinates (32 bytes)
 	RFC6979SignatureSize = 64
 
-	// ErrWrongHashSize when passed signature to VerifyRFC6979 has wrong size
+	// ErrWrongHashSize when passed signature to VerifyRFC6979 has wrong size.
 	ErrWrongHashSize = internal.Error("wrong hash size")
 
-	// ErrWrongSignature when passed signature to VerifyRFC6979 isn't valid
+	// ErrWrongSignature when passed signature to VerifyRFC6979 isn't valid.
 	ErrWrongSignature = internal.Error("wrong signature")
 )
 
@@ -26,11 +26,9 @@ const (
 // signature as a pair of integers.
 //
 // Note that FIPS 186-3 section 4.6 specifies that the hash should be truncated
-// to the byte-length of the subgroup. This function does not perform that
+// to the byte-length of the subgroup. This function does not perform that.
 func SignRFC6979(key *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
-	msgHash := sha256.Sum256(msg)
-
-	r, s, err := rfc6979.SignECDSA(key, msgHash[:], sha256.New)
+	r, s, err := rfc6979.SignECDSA(key, hashBytes(msg), sha256.New)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +44,12 @@ func decodeSignature(sig []byte) (*big.Int, *big.Int, error) {
 	return new(big.Int).SetBytes(sig[:32]), new(big.Int).SetBytes(sig[32:]), nil
 }
 
-// VerifyRFC6979 verifies the signature in r, s of hash using the public key, pub. Its
-// return value records whether the signature is valid.
-func VerifyRFC6979(key *ecdsa.PublicKey, hash, data []byte) error {
-	msgHash := sha256.Sum256(data)
-
-	if r, s, err := decodeSignature(hash); err != nil {
+// VerifyRFC6979 verifies the signature of msg using the public key. It
+// return nil only if signature is valid.
+func VerifyRFC6979(key *ecdsa.PublicKey, sig, msg []byte) error {
+	if r, s, err := decodeSignature(sig); err != nil {
 		return err
-	} else if !ecdsa.Verify(key, msgHash[:], r, s) {
+	} else if !ecdsa.Verify(key, hashBytes(msg), r, s) {
 		return ErrWrongSignature
 	}
 

--- a/wif.go
+++ b/wif.go
@@ -21,7 +21,7 @@ const (
 	// by last 4 bytes signature.
 	ErrBadChecksum = internal.Error("bad checksum")
 
-	// ErrEmptyPrivateKey when PK passed into WIFEncode method is nil
+	// ErrEmptyPrivateKey when PK passed into WIFEncode method is nil.
 	ErrEmptyPrivateKey = internal.Error("empty private key")
 )
 


### PR DESCRIPTION
It may be misleading when verify function takes signature as a hash
parameter. This commit suggested to use rfc6979 original naming
for the parameters:
- `msg` as the message to sign,
- `sig` as the signature of message.

All hashing operations are encapsulated inside of the Sign
and Verify functions.

Also there are comment fixes and re-usage of `hashBytes()` in rfc6979.