### PR TITLE
Change func Verify signature

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -191,7 +191,7 @@ func hashBytes(data []byte) []byte {
 
 // Verify verifies the signature of msg using the public key pub. It returns
 // nil only if signature is valid.
-func Verify(pub *ecdsa.PublicKey, sig, msg []byte) error {
+func Verify(pub *ecdsa.PublicKey, msg, sig []byte) error {
 	if r, s := unmarshalXY(sig); r == nil || s == nil {
 		return ErrCannotUnmarshal
 	} else if pub == nil {

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -112,13 +112,13 @@ func TestSignVerify(t *testing.T) {
 				r1, s1, err := ecdsa.Sign(rand.Reader, key, hashBytes(data))
 				require.NoError(t, err)
 
-				hash := marshalXY(r1, s1)
-				UnmarshalPublicKey(hash)
+				sign := marshalXY(r1, s1)
+				UnmarshalPublicKey(sign)
 			}
 
 			{ // 3. bad big.Ints
-				hash := marshalXY(big.NewInt(0), big.NewInt(1))
-				UnmarshalPublicKey(hash)
+				sign := marshalXY(big.NewInt(0), big.NewInt(1))
+				UnmarshalPublicKey(sign)
 			}
 		})
 	})
@@ -134,20 +134,20 @@ func TestSignVerify(t *testing.T) {
 			hashBytes(data))
 		require.NoError(t, err)
 
-		hash := marshalXY(r1, s1)
+		sign := marshalXY(r1, s1)
 
-		{ // This is just to validate, that we are on right way.. try to unmarshal R/S from hash
+		{ // This is just to validate, that we are on right way.. try to unmarshal R/S from sign
 			// validate bytes length
 			byteLen := (curve.Params().BitSize + 7) >> 3
-			require.Len(t, hash, 1+2*byteLen)
+			require.Len(t, sign, 1+2*byteLen)
 
 			// uncompressed form?
-			require.Equal(t, byte(4), hash[0])
+			require.Equal(t, byte(4), sign[0])
 
 			// validate R / S
 			p := curve.Params().P
-			r := new(big.Int).SetBytes(hash[1 : 1+byteLen])
-			s := new(big.Int).SetBytes(hash[1+byteLen:])
+			r := new(big.Int).SetBytes(sign[1 : 1+byteLen])
+			s := new(big.Int).SetBytes(sign[1+byteLen:])
 			require.True(t, r.Cmp(p) < 0)
 			require.True(t, s.Cmp(p) < 0)
 
@@ -155,7 +155,7 @@ func TestSignVerify(t *testing.T) {
 			// require.True(t, curve.IsOnCurve(r, s))
 		}
 
-		r2, s2 := unmarshalXY(hash)
+		r2, s2 := unmarshalXY(sign)
 		require.NotNil(t, r2)
 		require.NotNil(t, s2)
 
@@ -169,11 +169,11 @@ func TestSignVerify(t *testing.T) {
 			key  = test.DecodeKey(0)
 		)
 
-		hash, err := Sign(key, data)
+		sign, err := Sign(key, data)
 		require.NoError(t, err)
 
 		for i := 0; i < 100; i++ {
-			require.NoError(t, Verify(&key.PublicKey, hash, data))
+			require.NoError(t, Verify(&key.PublicKey, data, sign))
 		}
 	})
 }

--- a/rfc6979.go
+++ b/rfc6979.go
@@ -46,7 +46,7 @@ func decodeSignature(sig []byte) (*big.Int, *big.Int, error) {
 
 // VerifyRFC6979 verifies the signature of msg using the public key. It
 // return nil only if signature is valid.
-func VerifyRFC6979(key *ecdsa.PublicKey, sig, msg []byte) error {
+func VerifyRFC6979(key *ecdsa.PublicKey, msg, sig []byte) error {
 	if r, s, err := decodeSignature(sig); err != nil {
 		return err
 	} else if !ecdsa.Verify(key, hashBytes(msg), r, s) {

--- a/rfc6979_test.go
+++ b/rfc6979_test.go
@@ -67,7 +67,7 @@ func TestRFC6979(t *testing.T) {
 
 			require.Equal(t, sig, res, "step: %d, %02x", i, res)
 
-			require.NoErrorf(t, VerifyRFC6979(pub, sig, body), "step: %d", i)
+			require.NoErrorf(t, VerifyRFC6979(pub, body, sig), "step: %d", i)
 			offset += RFC6979SignatureSize
 		}
 
@@ -77,7 +77,7 @@ func TestRFC6979(t *testing.T) {
 			// It's not equals in Python and Go:
 			// require.Equal(t, sig, res, "step: %d, %02x", i, res)
 
-			require.NoErrorf(t, VerifyRFC6979(pub, sig, body), "step: %d", i)
+			require.NoErrorf(t, VerifyRFC6979(pub, body, sig), "step: %d", i)
 
 			offset += RFC6979SignatureSize
 		}


### PR DESCRIPTION
- Before `func Verify*(pub *ecdsa.PublicKey, sig, msg []byte) error`
- After `func Verify*(pub *ecdsa.PublicKey, msg, sig []byte) error`
- Update tests and replace `hash` with `sign` for signatures

Fix issue #5