### PR TITLE
Use SHA512 instead of SHA256

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -4,7 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"math/big"
 
@@ -183,9 +183,9 @@ func MarshalPrivateKey(key *ecdsa.PrivateKey) []byte {
 	return key.D.Bytes()
 }
 
-// hashBytes returns the sha256 sum.
+// hashBytes returns the sha512 sum.
 func hashBytes(data []byte) []byte {
-	buf := sha256.Sum256(data)
+	buf := sha512.Sum512(data)
 	return buf[:]
 }
 
@@ -203,7 +203,7 @@ func Verify(pub *ecdsa.PublicKey, sig, msg []byte) error {
 	return nil
 }
 
-// Sign signs a message using the private key. If the sha256 hash of msg
+// Sign signs a message using the private key. If the sha512 hash of msg
 // is longer than the bit-length of the private key's curve order, the hash
 // will be truncated to that length. It returns the signature as slice bytes.
 // The security of the private key depends on the entropy of rand.

--- a/rfc6979.go
+++ b/rfc6979.go
@@ -21,6 +21,12 @@ const (
 	ErrWrongSignature = internal.Error("wrong signature")
 )
 
+// hashBytesRFC6979 returns the sha256 sum.
+func hashBytesRFC6979(data []byte) []byte {
+	sign := sha256.Sum256(data)
+	return sign[:]
+}
+
 // SignRFC6979 signs an arbitrary length hash (which should be the result of
 // hashing a larger message) using the private key. It returns the
 // signature as a pair of integers.
@@ -28,7 +34,7 @@ const (
 // Note that FIPS 186-3 section 4.6 specifies that the hash should be truncated
 // to the byte-length of the subgroup. This function does not perform that.
 func SignRFC6979(key *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
-	r, s, err := rfc6979.SignECDSA(key, hashBytes(msg), sha256.New)
+	r, s, err := rfc6979.SignECDSA(key, hashBytesRFC6979(msg), sha256.New)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +55,7 @@ func decodeSignature(sig []byte) (*big.Int, *big.Int, error) {
 func VerifyRFC6979(key *ecdsa.PublicKey, sig, msg []byte) error {
 	if r, s, err := decodeSignature(sig); err != nil {
 		return err
-	} else if !ecdsa.Verify(key, hashBytes(msg), r, s) {
+	} else if !ecdsa.Verify(key, hashBytesRFC6979(msg), r, s) {
 		return ErrWrongSignature
 	}
 


### PR DESCRIPTION
For Verify[RFC6979](https://tools.ietf.org/html/rfc6979) we still using sha256 as described in RFC

Fix issue #4