### PR TITLE
Add leading zeros if `r` or `s` has less than 32 bytes

### DIFF
--- a/rfc6979.go
+++ b/rfc6979.go
@@ -38,7 +38,18 @@ func SignRFC6979(key *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
 		return nil, ErrEmptyPrivateKey
 	}
 	r, s := rfc6979.SignECDSA(key, hashBytesRFC6979(msg), sha256.New)
-	return append(r.Bytes(), s.Bytes()...), nil
+	rBytes, sBytes := r.Bytes(), s.Bytes()
+	signature := make([]byte, RFC6979SignatureSize)
+
+	// if `r` has less than 32 bytes, add leading zeros
+	ind := RFC6979SignatureSize/2 - len(rBytes)
+	copy(signature[ind:], rBytes)
+
+	// if `s` has less than 32 bytes, add leading zeros
+	ind = RFC6979SignatureSize - len(sBytes)
+	copy(signature[ind:], sBytes)
+
+	return signature, nil
 }
 
 func decodeSignature(sig []byte) (*big.Int, *big.Int, error) {

--- a/rfc6979_test.go
+++ b/rfc6979_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/nspcc-dev/neofs-crypto/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,5 +82,25 @@ func TestRFC6979(t *testing.T) {
 
 			offset += RFC6979SignatureSize
 		}
+	}
+}
+
+func TestRFC6979_ShortDecodePoints(t *testing.T) {
+	key := test.DecodeKey(1)
+
+	msgs := []string{
+		"6341922933e156ea5a53b8ea3fa4a80c", // this msg has 31 byte `s` point
+		"61b863d81f72e0e0d0353b1cb90d62ce", // this msg has 31 byte 'r' point
+	}
+
+	for i := range msgs {
+		msg, err := hex.DecodeString(msgs[i])
+		require.NoError(t, err)
+
+		signature, err := SignRFC6979(key, msg)
+		require.NoError(t, err, msgs[i])
+
+		err = VerifyRFC6979(&key.PublicKey, msg, signature)
+		require.NoError(t, err, msgs[i])
 	}
 }


### PR DESCRIPTION
`SignECDSA()` function returns two coordinates on elliptic curve.
Catenation of these coordinates is a 64 bytes signature. If
one of these coordinates have less than 32 significant bytes, then
it should have leading zeros.

It is similar to the issue https://github.com/nspcc-dev/neofs-crypto/pull/8, but applied for the rfc6979 functions. 

`neo-go` also adds leading zeros to `r` and `s`: https://github.com/nspcc-dev/neo-go/blob/6dc90232896f397e7a6302d1943b4bd450df2d16/pkg/crypto/keys/private_key.go#L121

```go
signature := make([]byte, curveOrderByteSize*2)
copy(signature[curveOrderByteSize-len(rBytes):], rBytes)
copy(signature[curveOrderByteSize*2-len(sBytes):], sBytes)
```

